### PR TITLE
chore(dependabot): change PR separator to be container tag compatible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,19 @@ version: 2
 updates:
   - package-ecosystem: docker
     directory: /
+    pull-request-branch-name:
+      separator: "-"
     schedule:
       interval: weekly
   - package-ecosystem: pip
     directory: /
+    pull-request-branch-name:
+      separator: "-"
     schedule:
       interval: weekly
   - package-ecosystem: github-actions
     directory: /
+    pull-request-branch-name:
+      separator: "-"
     schedule:
       interval: monthly


### PR DESCRIPTION
Make dependabot's PRs with a branch name that can be reused in image tagging.